### PR TITLE
Dictionary

### DIFF
--- a/javascript/lifecycle.js
+++ b/javascript/lifecycle.js
@@ -13,9 +13,9 @@ import { camelize } from './utils'
 // - element - the element that triggered the reflex (not necessarily the Stimulus controller's element)
 //
 const invokeLifecycleMethod = (stage, element, reflexId) => {
-  if (!element || !element.reflexData) return
+  if (!element || !element.reflexData[reflexId]) return
   const controller = element.reflexController
-  const reflex = element.reflexData.target
+  const reflex = element.reflexData[reflexId].target
   const reflexMethodName = reflex.split('#')[1]
 
   const specificLifecycleMethodName = ['before', 'after', 'finalize'].includes(
@@ -54,7 +54,7 @@ const invokeLifecycleMethod = (stage, element, reflexId) => {
 
   if (reflexes[reflexId] && stage === reflexes[reflexId].finalStage) {
     delete element.reflexController
-    delete element.reflexData
+    delete element.reflexData[reflexId]
     delete element.reflexError
     delete reflexes[reflexId]
   }
@@ -126,7 +126,7 @@ document.addEventListener(
 //
 export const dispatchLifecycleEvent = (stage, element, reflexId) => {
   if (!element) return
-  const { target } = element.reflexData || {}
+  const { target } = element.reflexData[reflexId] || {}
   element.dispatchEvent(
     new CustomEvent(`stimulus-reflex:${stage}`, {
       bubbles: true,

--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -221,14 +221,6 @@ const extendStimulusController = controller => {
           formData
         }
 
-        // include guaranteed reflex params
-        if (typeof this.guaranteedReflexParams === Object) {
-          element.reflexData.params = {
-            ...params,
-            ...this.guaranteedReflexParams
-          }
-        }
-
         subscription.send(element.reflexData)
       })
 
@@ -494,16 +486,10 @@ if (!document.stimulusReflexInitialized) {
 
     if (reflex.completedOperations < reflex.totalOperations) return
 
-    if (
-      stimulusReflex.resolveLate &&
-      stimulusReflex.resolveLate != 'afterFinalize'
-    )
+    if (stimulusReflex.resolveLate)
       setTimeout(() => promise.resolve({ element, event, data: promise.data }))
 
     setTimeout(() => dispatchLifecycleEvent('finalize', element, reflexId))
-
-    if (stimulusReflex.resolveLate == 'afterFinalize')
-      setTimeout(() => promise.resolve({ element, event, data: promise.data }))
   }
 
   document.addEventListener('cable-ready:after-inner-html', afterDOMUpdate)

--- a/javascript/stimulus_reflex.js
+++ b/javascript/stimulus_reflex.js
@@ -87,7 +87,8 @@ const createSubscription = controller => {
             controllerElement,
             reflexData.reflexController
           )
-          element.reflexData = reflexData
+          if (element.reflexData == undefined) element.reflexData = {}
+          element.reflexData[reflexId] = reflexData
           dispatchLifecycleEvent('before', element, reflexId)
           registerReflex(reflexData)
         }
@@ -204,24 +205,25 @@ const extendStimulusController = controller => {
 
       // lifecycle setup
       element.reflexController = this
-      element.reflexData = data
+      if (element.reflexData == undefined) element.reflexData = {}
+      element.reflexData[reflexId] = data
 
       dispatchLifecycleEvent('before', element, reflexId)
 
       setTimeout(() => {
-        const { params } = element.reflexData || {}
+        const { params } = element.reflexData[reflexId] || {}
         const formData =
           options['serializeForm'] == false
             ? ''
             : serializeForm(element.closest('form'), { element })
 
-        element.reflexData = {
+        element.reflexData[reflexId] = {
           ...data,
           params,
           formData
         }
 
-        subscription.send(element.reflexData)
+        subscription.send(element.reflexData[reflexId])
       })
 
       const promise = registerReflex(data)


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Bug Fix

## Description

SR v3.4.0.pre4 writes Reflex-specific data to the `element.reflexData`, paving the way for race conditions if multiple Reflexes are in play simultaineously.

## Why should this be added

This PR proposes to change `element.reflexData` to a dictionary. When a Reflex reads or writes data to it, those operations are keyed to the `reflexId`.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update
